### PR TITLE
Fixed build action script and file path for building

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,12 @@ name: 'Build and publish pipeline'
 
 ## Only builds when someone pushes to or PRs against main
 on:
-  push:
-    branches:
-      - main
+  ## Temporarily disabled builds on push to main ahead of develop
+  ## branch merge - develop has a slightly different directory
+  ## structure to main
+  # push:
+    # branches:
+      # - main
   pull_request:
     branches:
       - main
@@ -35,7 +38,7 @@ jobs:
     ## env variables are variables that we can refer to in different parts of our
     ## build pipeline
     env:
-      working-directory: ./src/InvoiceGenerator/InvoiceGenerator
+      working-directory: ./src/InvoiceGenerator
 
     ## The Steps section is where we define the steps required to run this job on
     ## the target machine.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,15 +2,20 @@ name: 'Build and publish pipeline'
 
 ## Only builds when someone pushes to or PRs against main
 on:
-  ## Temporarily disabled builds on push to main ahead of develop
-  ## branch merge - develop has a slightly different directory
-  ## structure to main
+  ## Temporarily disabled builds for this action, ahead of the
+  ## develop branch merge - develop has a slightly different
+  ## directory structure to main.
+  ## When completed, delete the newly created push rule and
+  ## un-comment the push and pull_request lines underneath it
+  push:
+    branches-ignore:
+      - '**'
   # push:
     # branches:
       # - main
-  pull_request:
-    branches:
-      - main
+  # pull_request:
+  #   branches:
+  #     - main
 
 jobs:
 


### PR DESCRIPTION
Took a look at the build action file (dotnet.yaml) and:

- renamed file to remove the unneeded "a" in the file extension
- temporarily stopped the build action from running completely
- updated the path used by the build action

This is a temporary bugfix ahead of a bug happening when develop is merged into main. After the develop merge has happened, we'll need to raise a new bugfix branch to re-enable the build action.